### PR TITLE
Admin updates

### DIFF
--- a/mbq/atomiq/admin.py
+++ b/mbq/atomiq/admin.py
@@ -91,16 +91,7 @@ class BaseTaskAdmin(admin.ModelAdmin):
 
 
 def get_name_from_topic_arn(arn):
-    if len(arn) <= 40:
-        return arn
-
-    start = arn[:7]
-    end = arn[-32:]
-
-    if ':' in end:
-        end = end.split(':')[-1]
-
-    return '{}...{}'.format(start, end)
+   return arn.split(':')[-1]
 
 
 class SNSTopicListFilter(admin.SimpleListFilter):
@@ -139,16 +130,7 @@ class SNSTaskAdmin(BaseTaskAdmin):
 
 
 def get_name_from_queue_url(url):
-    if len(url) <= 40:
-        return url
-
-    start = url[:8]
-    end = url[-32:]
-
-    if '/' in end:
-        end = end.split('/')[-1]
-
-    return '{}.../{}'.format(start, end)
+    return url.split('/')[-1]
 
 
 class SQSTopicListFilter(admin.SimpleListFilter):

--- a/mbq/atomiq/admin.py
+++ b/mbq/atomiq/admin.py
@@ -99,7 +99,7 @@ class SNSTopicListFilter(admin.SimpleListFilter):
     parameter_name = 'topic_arn'
 
     def lookups(self, request, model_admin):
-        qs = model_admin.get_queryset(request)
+        qs = model_admin.get_queryset(request).order_by('topic_arn')
         topic_arns = qs.values_list('topic_arn', flat=True).distinct()
         for arn in topic_arns:
             yield (arn, get_name_from_topic_arn(arn))
@@ -138,7 +138,7 @@ class SQSTopicListFilter(admin.SimpleListFilter):
     parameter_name = 'queue_url'
 
     def lookups(self, request, model_admin):
-        qs = model_admin.get_queryset(request)
+        qs = model_admin.get_queryset(request).order_by('queue_url')
         queue_urls = qs.values_list('queue_url', flat=True).distinct()
         for url in queue_urls:
             yield (url, get_name_from_queue_url(url))

--- a/mbq/atomiq/admin.py
+++ b/mbq/atomiq/admin.py
@@ -91,7 +91,7 @@ class BaseTaskAdmin(admin.ModelAdmin):
 
 
 def get_name_from_topic_arn(arn):
-   return arn.split(':')[-1]
+    return arn.split(':')[-1]
 
 
 class SNSTopicListFilter(admin.SimpleListFilter):

--- a/mbq/atomiq/admin.py
+++ b/mbq/atomiq/admin.py
@@ -42,6 +42,9 @@ class BaseTaskAdmin(admin.ModelAdmin):
     def has_delete_permission(self, request, obj=None):
         return False
 
+    def has_add_permission(self, *args, **kwrargs):
+        return False
+
     def admin_error_message(self, task):
         return format_html(
             '<div style="max-width:500px" >{}</div>',

--- a/mbq/atomiq/admin.py
+++ b/mbq/atomiq/admin.py
@@ -106,7 +106,7 @@ class SNSTopicListFilter(admin.SimpleListFilter):
 
     def lookups(self, request, model_admin):
         qs = model_admin.get_queryset(request)
-        topic_arns = set(qs.values_list('topic_arn', flat=True))
+        topic_arns = qs.values_list('topic_arn', flat=True).distinct()
         for arn in topic_arns:
             yield (arn, get_name_from_topic_arn(arn))
 
@@ -154,7 +154,7 @@ class SQSTopicListFilter(admin.SimpleListFilter):
 
     def lookups(self, request, model_admin):
         qs = model_admin.get_queryset(request)
-        queue_urls = set(qs.values_list('queue_url', flat=True))
+        queue_urls = qs.values_list('queue_url', flat=True).distinct()
         for url in queue_urls:
             yield (url, get_name_from_queue_url(url))
 


### PR DESCRIPTION
1. remove add permissions
2. topic and queue filters just use names of those resources. the full urls are still going to be in the detail views. The functions are so simple I don't think docstrings are required
3. filter lookups use distinct querysets instead of converting to sets (something that was brought up in that feedback PR)