### PR TITLE
refactor consumer

### DIFF
--- a/mbq/atomiq/consumers.py
+++ b/mbq/atomiq/consumers.py
@@ -1,15 +1,12 @@
 import importlib
 import json
 import traceback
-from time import sleep
 
 from django.db import transaction
 
 import arrow
 
-import rollbar
-
-from . import _collector, constants, models, utils
+from . import constants, models
 
 
 class BaseConsumer(object):

--- a/mbq/atomiq/consumers.py
+++ b/mbq/atomiq/consumers.py
@@ -41,9 +41,9 @@ class BaseConsumer(object):
         return task
 
     def get_next_enqueued_task(self):
-        try:
-            task = self.model.objects.available_for_processing()[:1].select_for_update().get()
-        except self.model.DoesNotExist:
+        task = self.model.objects.available_for_processing()[:1].select_for_update().first()
+
+        if not task:
             raise exceptions.NoAvailableTasksToProcess()
 
         return task

--- a/mbq/atomiq/consumers.py
+++ b/mbq/atomiq/consumers.py
@@ -14,22 +14,12 @@ from . import _collector, constants, models, utils
 
 class BaseConsumer(object):
 
-    def run(self):
-        try:
-            with transaction.atomic():
-                task = self.model.objects.available_for_processing()[:1].select_for_update().get()
-                execution_started_at = arrow.utcnow()
-                self.process_task(task)
-                execution_ended_at = arrow.utcnow()
-            self.send_task_execution_metrics(task, execution_started_at, execution_ended_at)
-        except self.model.DoesNotExist:
-            sleep(0.5)
-        except Exception:
-            rollbar.report_exc_info()
-            sleep(0.5)
+    @transaction.atomic
+    def process_one_task(self):
+        task = self.model.objects.available_for_processing()[:1].select_for_update().get()
 
-    def process_task(self, task):
         task.number_of_attempts += 1
+
         try:
             self.publish(task)
         except Exception as e:
@@ -40,46 +30,18 @@ class BaseConsumer(object):
                 task.failed_at = arrow.utcnow().datetime
                 task.error_message = str(e)
                 task.stacktrace = traceback.format_exc()
-                rollbar.report_exc_info()
             else:
                 # Task will be retried. It will be put back on the queue and made
                 # invisible to the consumer using an exponential backoff policy.
                 backoff_time = 2**task.number_of_attempts
                 task.visible_after = arrow.utcnow().shift(seconds=backoff_time).datetime
         else:
-            # Task execution succeeded.
             task.state = constants.TaskStates.SUCCEEDED
             task.succeeded_at = arrow.utcnow().datetime
 
         task.save()
 
-    def send_task_execution_metrics(self, task, execution_started_at, execution_ended_at):
-        dd_tags = {
-            'end_state': task.state,
-            'result': 'success' if task.state == constants.TaskStates.SUCCEEDED else 'error',
-            'queue_type': self.queue_type,
-        }
-        _collector.increment(
-            'task',
-            tags=dd_tags,
-        )
-
-        _collector.timing(
-            'task.wait_time_ms',
-            utils.time_difference_ms(task.visible_after, execution_started_at),
-            tags=dd_tags,
-        )
-        _collector.timing(
-            'task.execution_time_ms',
-            utils.time_difference_ms(execution_started_at, execution_ended_at),
-            tags=dd_tags,
-        )
-        if task.state == constants.TaskStates.SUCCEEDED:
-            _collector.timing(
-                'task.turnaround_time_ms',
-                utils.time_difference_ms(task.created_at, task.succeeded_at),
-                tags=dd_tags,
-            )
+        return task
 
     def publish(self, task):
         raise NotImplementedError('publish must be implemented by subclasses.')

--- a/mbq/atomiq/exceptions.py
+++ b/mbq/atomiq/exceptions.py
@@ -1,2 +1,5 @@
 class TransactionError(Exception):
     pass
+
+class NoAvailableTasksToProcess(Exception):
+    pass

--- a/mbq/atomiq/exceptions.py
+++ b/mbq/atomiq/exceptions.py
@@ -1,5 +1,6 @@
 class TransactionError(Exception):
     pass
 
+
 class NoAvailableTasksToProcess(Exception):
     pass

--- a/mbq/atomiq/management/commands/atomic_run_consumer.py
+++ b/mbq/atomiq/management/commands/atomic_run_consumer.py
@@ -80,7 +80,7 @@ class Command(BaseCommand):
             'queue_type': queue,
         }
 
-         _collector.increment(
+        _collector.increment(
             'task',
             tags=tags,
         )

--- a/mbq/atomiq/management/commands/atomic_run_consumer.py
+++ b/mbq/atomiq/management/commands/atomic_run_consumer.py
@@ -8,7 +8,7 @@ import arrow
 
 import rollbar
 
-from ... import _collector, constants, consumers, utils
+from ... import _collector, constants, consumers, exceptions, utils
 
 
 class SignalHandler():
@@ -121,7 +121,7 @@ class Command(BaseCommand):
                     execution_start = arrow.utcnow().datetime
                     processed_task = consumer.process_one_task()
                     execution_end = arrow.utcnow().datetime
-                except Consumer.model.DoesNotExist:
+                except exceptions.NoAvailableTasksToProcess:
                     sleep(1)
                 except Exception:
                     rollbar.report_exc_info()

--- a/mbq/atomiq/management/commands/atomic_run_consumer.py
+++ b/mbq/atomiq/management/commands/atomic_run_consumer.py
@@ -1,5 +1,6 @@
 import collections
 import signal
+from time import sleep
 
 from django.core.management.base import BaseCommand
 
@@ -26,6 +27,7 @@ class Command(BaseCommand):
 
     def __init__(self, *args, **kwargs):
         super(BaseCommand, self).__init__(*args, **kwargs)
+
         self.signal_handler = SignalHandler()
         signal.signal(signal.SIGINT, self.signal_handler.handle_signal)
         signal.signal(signal.SIGTERM, self.signal_handler.handle_signal)
@@ -57,7 +59,7 @@ class Command(BaseCommand):
         self.cleanup_old_tasks(options['queue'])
 
     @utils.debounce(seconds=15)
-    def collect_metrics(self, **options):
+    def collect_queue_metrics(self, **options):
         queue_type = options['queue']
         model = self.consumers[queue_type].model
 
@@ -69,6 +71,37 @@ class Command(BaseCommand):
                 'state_total',
                 state_counts.get(task_state, 0),
                 tags={'state': task_state, 'queue_type': queue_type},
+            )
+
+    def collect_task_metrics(self, queue, task, execution_start, execution_end):
+        tags = {
+            'end_state': task.state,
+            'result': 'success' if task.state == constants.TaskStates.SUCCEEDED else 'error',
+            'queue_type': queue,
+        }
+
+         _collector.increment(
+            'task',
+            tags=tags,
+        )
+
+        _collector.timing(
+            'task.wait_time_ms',
+            utils.time_difference_ms(task.visible_after, execution_start),
+            tags=tags,
+        )
+
+        _collector.timing(
+            'task.execution_time_ms',
+            utils.time_difference_ms(execution_start, execution_end),
+            tags=tags,
+        )
+
+        if task.state == constants.TaskStates.SUCCEEDED:
+            _collector.timing(
+                'task.turnaround_time_ms',
+                utils.time_difference_ms(task.created_at, task.succeeded_at),
+                tags=tags,
             )
 
     def handle(self, *args, **options):
@@ -84,9 +117,25 @@ class Command(BaseCommand):
             consumer = Consumer(**consumer_kwargs)
 
             while self.signal_handler.should_continue():
-                consumer.run()
-                self.collect_metrics(**options)
-                self.run_delayed_cleanup(**options)
+                try:
+                    execution_start = arrow.utcnow().datetime
+                    processed_task = consumer.process_one_task()
+                    execution_end = arrow.utcnow().datetime
+                except Consumer.model.DoesNotExist:
+                    sleep(1)
+                except Exception:
+                    rollbar.report_exc_info()
+                    sleep(1)
+                else:
+                    self.collect_task_metrics(
+                        queue_type,
+                        processed_task,
+                        execution_start,
+                        execution_end,
+                    )
+                finally:
+                    self.collect_queue_metrics(**options)
+                    self.run_delayed_cleanup(**options)
 
         except Exception:
             rollbar.report_exc_info()

--- a/mbq/atomiq/utils.py
+++ b/mbq/atomiq/utils.py
@@ -100,7 +100,7 @@ def _frame_locals_contains_testcase_class(frame):
 
 def send_errors_to_rollbar(func):
 
-    @wraps(func)
+    @functools.wraps(func)
     def wrapper(*args, **kwargs):
         try:
             func(*args, **kwargs)

--- a/mbq/atomiq/utils.py
+++ b/mbq/atomiq/utils.py
@@ -5,6 +5,8 @@ import time
 from django.db import transaction
 from django.test import TestCase
 
+import rollbar
+
 
 def time_difference_ms(start_datetime, end_datetime):
     diff_in_seconds = (end_datetime - start_datetime).total_seconds()
@@ -94,3 +96,16 @@ def _frame_locals_contains_testcase_class(frame):
             return True
 
     return False
+
+
+def send_errors_to_rollbar(func):
+
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        try:
+            func(*args, **kwargs)
+        except Exception:
+            rollbar.report_exc_info()
+            raise
+
+    return wrapper

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -15,18 +15,21 @@ class RunConsumerCommandTest(TestCase):
     @mock.patch('mbq.atomiq.consumers.SNSConsumer.process_one_task')
     def test_run_consumer_sns(self, process_one_task, SignalHandlerMock):
         SignalHandlerMock.return_value.should_continue.side_effect = [True, True, False]
+        process_one_task.return_value = models.SNSTask.objects.create()
         call_command('atomic_run_consumer', '--queue=sns')
         self.assertEqual(process_one_task.call_count, 2)
 
     @mock.patch('mbq.atomiq.consumers.SQSConsumer.process_one_task')
     def test_run_consumer_sqs(self, process_one_task, SignalHandlerMock):
         SignalHandlerMock.return_value.should_continue.side_effect = [True, True, False]
+        process_one_task.return_value = models.SNSTask.objects.create()
         call_command('atomic_run_consumer', '--queue=sqs')
         self.assertEqual(process_one_task.call_count, 2)
 
     @mock.patch('mbq.atomiq.consumers.CeleryConsumer.process_one_task')
     def test_run_consumer_celery(self, process_one_task, SignalHandlerMock):
         SignalHandlerMock.return_value.should_continue.side_effect = [True, True, False]
+        process_one_task.return_value = models.SNSTask.objects.create()
         call_command('atomic_run_consumer', '--queue=celery', '--celery-app=tests.celery')
         self.assertEqual(process_one_task.call_count, 2)
 
@@ -132,8 +135,8 @@ class CollectMetricsTest(TestCase):
             'queue_type': constants.QueueType.SNS,
         }
 
-        execution_started_at = arrow.utcnow().shift(seconds=0.123)
-        execution_ended_at = arrow.utcnow().shift(seconds=0.579)
+        execution_started_at = arrow.utcnow().shift(seconds=0.123).datetime
+        execution_ended_at = arrow.utcnow().shift(seconds=0.579).datetime
 
         command.collect_task_metrics(
             constants.QueueType.SNS,
@@ -180,8 +183,8 @@ class CollectMetricsTest(TestCase):
             'queue_type': 'sns',
         }
 
-        execution_started_at = arrow.utcnow().shift(seconds=0.123)
-        execution_ended_at = arrow.utcnow().shift(seconds=0.579)
+        execution_started_at = arrow.utcnow().shift(seconds=0.123).datetime
+        execution_ended_at = arrow.utcnow().shift(seconds=0.579).datetime
 
         command.collect_task_metrics(
             constants.QueueType.SNS,

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -2,7 +2,7 @@ from django.core.management import call_command
 from django.test import TestCase
 
 import arrow
-from mbq.atomiq import constants, models
+from mbq.atomiq import constants, exceptions, models
 from mbq.atomiq.management.commands import atomic_run_consumer
 from tests.compat import mock
 
@@ -34,7 +34,7 @@ class RunConsumerCommandTest(TestCase):
     @mock.patch('mbq.atomiq.consumers.CeleryConsumer.process_one_task')
     def test_sleeps_when_queue_is_empty(self, process_task, sleep, SignalHandlerMock):
         SignalHandlerMock.return_value.should_continue.side_effect = [True, False]
-        process_task.side_effect = models.SQSTask.DoesNotExist
+        process_task.side_effect = exceptions.NoAvailableTasksToProcess
         call_command('atomic_run_consumer', '--queue=sqs')
         self.assertEqual(sleep.call_count, 1)
 

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -12,23 +12,39 @@ import freezegun
 @mock.patch('mbq.atomiq.management.commands.atomic_run_consumer.SignalHandler')
 class RunConsumerCommandTest(TestCase):
 
-    @mock.patch('mbq.atomiq.management.commands.atomic_run_consumer.consumers.SNSConsumer.run')
-    def test_run_consumer_sns(self, run, SignalHandlerMock):
+    @mock.patch('mbq.atomiq.consumers.SNSConsumer.process_one_task')
+    def test_run_consumer_sns(self, process_one_task, SignalHandlerMock):
         SignalHandlerMock.return_value.should_continue.side_effect = [True, True, False]
         call_command('atomic_run_consumer', '--queue=sns')
-        self.assertEqual(run.call_count, 2)
+        self.assertEqual(process_one_task.call_count, 2)
 
-    @mock.patch('mbq.atomiq.management.commands.atomic_run_consumer.consumers.SQSConsumer.run')
-    def test_run_consumer_sqs(self, run, SignalHandlerMock):
+    @mock.patch('mbq.atomiq.consumers.SQSConsumer.process_one_task')
+    def test_run_consumer_sqs(self, process_one_task, SignalHandlerMock):
         SignalHandlerMock.return_value.should_continue.side_effect = [True, True, False]
         call_command('atomic_run_consumer', '--queue=sqs')
-        self.assertEqual(run.call_count, 2)
+        self.assertEqual(process_one_task.call_count, 2)
 
-    @mock.patch('mbq.atomiq.management.commands.atomic_run_consumer.consumers.CeleryConsumer.run')
-    def test_run_consumer_celery(self, run, SignalHandlerMock):
+    @mock.patch('mbq.atomiq.consumers.CeleryConsumer.process_one_task')
+    def test_run_consumer_celery(self, process_one_task, SignalHandlerMock):
         SignalHandlerMock.return_value.should_continue.side_effect = [True, True, False]
         call_command('atomic_run_consumer', '--queue=celery', '--celery-app=tests.celery')
-        self.assertEqual(run.call_count, 2)
+        self.assertEqual(process_one_task.call_count, 2)
+
+    @mock.patch('mbq.atomiq.management.commands.atomic_run_consumer.sleep')
+    @mock.patch('mbq.atomiq.consumers.CeleryConsumer.process_one_task')
+    def test_sleeps_when_queue_is_empty(self, process_task, sleep, SignalHandlerMock):
+        SignalHandlerMock.return_value.should_continue.side_effect = [True, False]
+        process_task.side_effect = models.SQSTask.DoesNotExist
+        call_command('atomic_run_consumer', '--queue=sqs')
+        self.assertEqual(sleep.call_count, 1)
+
+    @mock.patch('mbq.atomiq.management.commands.atomic_run_consumer.sleep')
+    @mock.patch('mbq.atomiq.consumers.CeleryConsumer.process_one_task')
+    def test_sleeps_on_unexpected_error(self, process_task, sleep, SignalHandlerMock):
+        SignalHandlerMock.return_value.should_continue.side_effect = [True, False]
+        process_task.side_effect = Exception
+        call_command('atomic_run_consumer', '--queue=sqs')
+        self.assertEqual(sleep.call_count, 1)
 
 
 @mock.patch('mbq.atomiq.constants.DEFAULT_DAYS_TO_KEEP_OLD_TASKS', 30)
@@ -96,3 +112,99 @@ class ClenupTasksTest(TestCase):
             self.assertTrue(models.SNSTask.objects.filter(id=task_processed2.id).exists())
             self.assertFalse(models.SNSTask.objects.filter(id=task_deleted3.id).exists())
             self.assertFalse(models.SNSTask.objects.filter(id=task_processed3.id).exists())
+
+
+@mock.patch('mbq.metrics.Collector.timing')
+@mock.patch('mbq.metrics.Collector.increment')
+class CollectMetricsTest(TestCase):
+
+    @freezegun.freeze_time()
+    def test_collect_metrics_success(self, increment, timing):
+        command = atomic_run_consumer.Command()
+        task = models.SNSTask.objects.create(
+            state=constants.TaskStates.SUCCEEDED,
+            visible_after=arrow.utcnow().shift(seconds=0.012).datetime,
+            succeeded_at=arrow.utcnow().shift(seconds=0.471).datetime
+        )
+        expected_tags = {
+            'end_state': constants.TaskStates.SUCCEEDED,
+            'result': 'success',
+            'queue_type': constants.QueueType.SNS,
+        }
+
+        execution_started_at = arrow.utcnow().shift(seconds=0.123)
+        execution_ended_at = arrow.utcnow().shift(seconds=0.579)
+
+        command.collect_task_metrics(
+            constants.QueueType.SNS,
+            task,
+            execution_started_at,
+            execution_ended_at,
+        )
+
+        increment.assert_called_once_with(
+            'task',
+            tags=expected_tags,
+        )
+
+        wait_time = mock.call(
+            'task.wait_time_ms',
+            111.0,
+            tags=expected_tags
+        )
+        execution_time = mock.call(
+            'task.execution_time_ms',
+            456.0,
+            tags=expected_tags
+        )
+
+        turnaround_time = mock.call(
+            'task.turnaround_time_ms',
+            471.0,
+            tags=expected_tags
+        )
+
+        self.assertEqual(timing.call_count, 3)
+        timing.assert_has_calls([wait_time, execution_time, turnaround_time])
+
+    @freezegun.freeze_time()
+    def test_collect_metrics_error(self, increment, timing):
+        command = atomic_run_consumer.Command()
+
+        task = models.SNSTask.objects.create(
+            visible_after=arrow.utcnow().shift(seconds=0.012).datetime,
+        )
+        expected_tags = {
+            'end_state': constants.TaskStates.ENQUEUED,
+            'result': 'error',
+            'queue_type': 'sns',
+        }
+
+        execution_started_at = arrow.utcnow().shift(seconds=0.123)
+        execution_ended_at = arrow.utcnow().shift(seconds=0.579)
+
+        command.collect_task_metrics(
+            constants.QueueType.SNS,
+            task,
+            execution_started_at,
+            execution_ended_at,
+        )
+
+        increment.assert_called_once_with(
+            'task',
+            tags=expected_tags,
+        )
+
+        wait_time = mock.call(
+            'task.wait_time_ms',
+            111.0,
+            tags=expected_tags
+        )
+        execution_time = mock.call(
+            'task.execution_time_ms',
+            456.0,
+            tags=expected_tags
+        )
+
+        self.assertEqual(timing.call_count, 2)
+        timing.assert_has_calls([wait_time, execution_time])

--- a/tests/test_consumers.py
+++ b/tests/test_consumers.py
@@ -13,8 +13,8 @@ import freezegun
 class ProcessTasksTest(TestCase):
 
     @classmethod
-    def setUpTestData(self):
-        self.consumer = consumers.SNSConsumer()
+    def setUpTestData(cls):
+        cls.consumer = consumers.SNSConsumer()
 
     def test_process_tasks_successfully(self, publish):
         task = SNSTask.objects.create()

--- a/tests/test_consumers.py
+++ b/tests/test_consumers.py
@@ -44,7 +44,6 @@ class ProcessTasksTest(TestCase):
                 attempt += 1
                 frozen_time.tick(delta=(expected_visible_after - arrow.utcnow()))
 
-
     def test_process_tasks_with_final_failure(self, publish):
         # Change number_of_attempts so the consumer thinks this is the last retry
         task = SNSTask.objects.create()

--- a/tests/test_consumers.py
+++ b/tests/test_consumers.py
@@ -12,310 +12,73 @@ import freezegun
 @mock.patch('mbq.atomiq.consumers.SNSConsumer.publish')
 class ProcessTasksTest(TestCase):
 
-    def setUp(self):
-        freezer = freezegun.freeze_time()
-        freezer.start()
-        self.addCleanup(freezer.stop)
-
-        self.task_ready = SNSTask.objects.create(state=TaskStates.ENQUEUED)
-        self.task_ready_past = SNSTask.objects.create(
-            state=TaskStates.ENQUEUED,
-            visible_after=arrow.utcnow().shift(seconds=-3).datetime,
-        )
-        self.task_ready_now = SNSTask.objects.create(
-            state=TaskStates.ENQUEUED,
-            visible_after=arrow.utcnow().datetime,
-        )
+    @classmethod
+    def setUpTestData(self):
         self.consumer = consumers.SNSConsumer()
 
     def test_process_tasks_successfully(self, publish):
-
-        self.consumer.process_task(self.task_ready)
-        self.assertEquals(self.task_ready.state, TaskStates.SUCCEEDED)
-        self.assertEquals(self.task_ready.number_of_attempts, 1)
-        self.assertEquals(self.task_ready.succeeded_at, arrow.utcnow().datetime)
-
-        self.consumer.process_task(self.task_ready_past)
-        self.assertEquals(self.task_ready_past.state, TaskStates.SUCCEEDED)
-        self.assertEquals(self.task_ready_past.number_of_attempts, 1)
-        self.assertEquals(self.task_ready_past.succeeded_at, arrow.utcnow().datetime)
+        task = SNSTask.objects.create()
+        self.consumer.process_one_task()
+        task.refresh_from_db()
+        self.assertEquals(task.state, TaskStates.SUCCEEDED)
+        self.assertEquals(task.number_of_attempts, 1)
+        self.assertIsNotNone(task.succeeded_at)
 
     def test_process_tasks_with_requeue(self, publish):
         # Makes publish raise an exception so the tasks fail
         publish.side_effect = Exception
-        self.consumer.process_task(self.task_ready)
-        expected_visible_after = arrow.utcnow().shift(seconds=2)
+        task = SNSTask.objects.create()
 
-        # These tasks should be processed and an exception will raise in the publish
-        # function. They should be requeued with a visible_after in the future
-        self.assertEquals(self.task_ready.state, TaskStates.ENQUEUED)
-        self.assertEquals(self.task_ready.number_of_attempts, 1)
-        self.assertEquals(self.task_ready.succeeded_at, None)
-        self.assertEquals(self.task_ready.visible_after, expected_visible_after)
+        attempt = 1
+        with freezegun.freeze_time() as frozen_time:
+            while attempt < MAX_ATTEMPTS_TO_PROCESS_TASKS:
+                self.consumer.process_one_task()
 
-        # This task has a visible_after which is in the past, so it should be requeued
-        # the same way as the first task.
-        self.consumer.process_task(self.task_ready_past)
-        self.assertEquals(self.task_ready_past.state, TaskStates.ENQUEUED)
-        self.assertEquals(self.task_ready_past.number_of_attempts, 1)
-        self.assertEquals(self.task_ready_past.visible_after, expected_visible_after)
-        self.assertEquals(self.task_ready_past.succeeded_at, None)
+                task.refresh_from_db()
+
+                expected_visible_after = arrow.utcnow().shift(seconds=2**attempt)
+                self.assertEquals(task.state, TaskStates.ENQUEUED)
+                self.assertEquals(task.number_of_attempts, attempt)
+                self.assertEquals(task.visible_after, expected_visible_after)
+
+                attempt += 1
+                frozen_time.tick(delta=(expected_visible_after - arrow.utcnow()))
+
 
     def test_process_tasks_with_final_failure(self, publish):
         # Change number_of_attempts so the consumer thinks this is the last retry
-        self.task_ready.number_of_attempts = MAX_ATTEMPTS_TO_PROCESS_TASKS
-        self.task_ready_past.number_of_attempts = MAX_ATTEMPTS_TO_PROCESS_TASKS
+        task = SNSTask.objects.create()
+        task.number_of_attempts = MAX_ATTEMPTS_TO_PROCESS_TASKS - 1
+        task.save()
 
         # Makes publish raise an exception so the tasks fail
         publish.side_effect = Exception('Test Error Message')
-        self.consumer.process_task(self.task_ready)
-
+        self.consumer.process_one_task()
+        task.refresh_from_db()
         # These tasks should be processed with an exception raised in the publish function.
         # Since they have already been retried the max number of times,
         # they should be transitioned to the FAILED state.
-        self.assertEquals(self.task_ready.state, TaskStates.FAILED)
-        self.assertEquals(self.task_ready.number_of_attempts, MAX_ATTEMPTS_TO_PROCESS_TASKS + 1)
-        self.assertEquals(self.task_ready.failed_at, arrow.utcnow().datetime)
-        self.assertEquals(self.task_ready.error_message, 'Test Error Message')
+        self.assertEquals(task.state, TaskStates.FAILED)
+        self.assertEquals(task.number_of_attempts, MAX_ATTEMPTS_TO_PROCESS_TASKS)
+        self.assertIsNotNone(task.failed_at)
+        self.assertEquals(task.error_message, 'Test Error Message')
         # A hacky way of testing that the stacktrace field is being set to something
         # that is likely an actual stacktrace.
         # Using assertEquals on the stacktrace field would be a very brittle test,
         # since refactoring the code would change the stacktrace and break the tests.
         self.assertTrue(
-            'Traceback (most recent call last):' in self.task_ready.stacktrace
-        )
-
-        self.consumer.process_task(self.task_ready_past)
-        self.assertEquals(self.task_ready_past.state, TaskStates.FAILED)
-        self.assertEquals(
-            self.task_ready_past.number_of_attempts,
-            MAX_ATTEMPTS_TO_PROCESS_TASKS + 1
-        )
-        self.assertEquals(self.task_ready_past.failed_at, arrow.utcnow().datetime)
-        self.assertEquals(self.task_ready_past.error_message, 'Test Error Message')
-        self.assertTrue(
-            'Traceback (most recent call last):' in self.task_ready_past.stacktrace
+            'Traceback (most recent call last):' in task.stacktrace
         )
 
     def test_process_tasks_with_final_success(self, sns_publish):
         # Change number_of_attempts so the consumer thinks this is the last retry
-        self.task_ready.number_of_attempts = MAX_ATTEMPTS_TO_PROCESS_TASKS
-        self.task_ready_past.number_of_attempts = MAX_ATTEMPTS_TO_PROCESS_TASKS
+        task = SNSTask.objects.create()
+        task.number_of_attempts = MAX_ATTEMPTS_TO_PROCESS_TASKS - 1
+        task.save()
 
-        self.consumer.process_task(self.task_ready)
+        self.consumer.process_one_task()
+        task.refresh_from_db()
         # These tasks should be processed successfully and transitioned to SUCCEEDED
-        self.assertEquals(self.task_ready.state, TaskStates.SUCCEEDED)
-        self.assertEquals(self.task_ready.number_of_attempts, MAX_ATTEMPTS_TO_PROCESS_TASKS + 1)
-        self.assertEquals(self.task_ready.succeeded_at, arrow.utcnow().datetime)
-
-        self.consumer.process_task(self.task_ready_past)
-        self.assertEquals(self.task_ready_past.state, TaskStates.SUCCEEDED)
-        self.assertEquals(
-            self.task_ready_past.number_of_attempts,
-            MAX_ATTEMPTS_TO_PROCESS_TASKS + 1
-        )
-        self.assertEquals(self.task_ready_past.succeeded_at, arrow.utcnow().datetime)
-
-
-@mock.patch('mbq.atomiq.consumers.BaseConsumer.process_task')
-class RunConsumerTest(TestCase):
-
-    def setUp(self):
-        freezer = freezegun.freeze_time()
-        freezer.start()
-        self.addCleanup(freezer.stop)
-
-        self.consumer = consumers.SNSConsumer()
-        self.topic_arn = 'test_topic_arn'
-        self.payload = {'test': 'payload'}
-
-    def test_run_consumer_finds_task(self, process_task):
-        task = SNSTask.objects.create(
-            state=TaskStates.ENQUEUED,
-            topic_arn=self.topic_arn,
-            payload=self.payload,
-        )
-
-        self.consumer.run()
-        process_task.assert_called_once_with(task)
-
-    @mock.patch('mbq.atomiq.consumers.sleep')
-    def test_run_consumer_finds_no_tasks_and_sleeps(self, sleep, process_task):
-        self.consumer.run()
-        process_task.assert_not_called()
-        sleep.assert_called_once_with(0.5)
-
-    @mock.patch('mbq.atomiq.consumers.sleep')
-    def test_run_consumer_skips_unavailable_tasks_and_sleeps(self, sleep, process_task):
-        SNSTask.objects.create(
-            state=TaskStates.DELETED,
-            topic_arn=self.topic_arn,
-            payload=self.payload,
-        )
-        SNSTask.objects.create(
-            state=TaskStates.FAILED,
-            topic_arn=self.topic_arn,
-            payload=self.payload,
-        )
-        SNSTask.objects.create(
-            state=TaskStates.ENQUEUED,
-            visible_after=arrow.utcnow().shift(seconds=2).datetime,
-            topic_arn=self.topic_arn,
-            payload=self.payload,
-        )
-
-        self.consumer.run()
-        process_task.assert_not_called()
-        sleep.assert_called_once_with(0.5)
-
-    def test_run_consumer_skips_unavailable_tasks(self, process_task):
-        SNSTask.objects.create(
-            state=TaskStates.DELETED,
-            topic_arn=self.topic_arn,
-            payload=self.payload,
-        )
-        SNSTask.objects.create(
-            state=TaskStates.FAILED,
-            topic_arn=self.topic_arn,
-            payload=self.payload,
-        )
-        SNSTask.objects.create(
-            state=TaskStates.ENQUEUED,
-            visible_after=arrow.utcnow().shift(seconds=2).datetime,
-            topic_arn=self.topic_arn,
-            payload=self.payload,
-        )
-
-        task_ready_past = SNSTask.objects.create(
-            state=TaskStates.ENQUEUED,
-            visible_after=arrow.utcnow().shift(seconds=-1).datetime,
-            topic_arn=self.topic_arn,
-            payload=self.payload,
-        )
-
-        SNSTask.objects.create(
-            state=TaskStates.ENQUEUED,
-            topic_arn=self.topic_arn,
-            payload=self.payload,
-        )
-
-        self.consumer.run()
-        process_task.assert_called_with(task_ready_past)
-
-    @mock.patch('mbq.atomiq.consumers.sleep')
-    def test_run_consumer_sleeps_on_unexpected_error(self, sleep, process_task):
-        SNSTask.objects.create(
-            state=TaskStates.ENQUEUED,
-            topic_arn=self.topic_arn,
-            payload=self.payload
-        )
-        process_task.side_effect = Exception
-        self.consumer.run()
-        self.assertEquals(sleep.call_count, 1)
-
-
-@mock.patch('mbq.atomiq.consumers.SNSConsumer.publish')
-class RequeueForRetryTest(TestCase):
-
-    @freezegun.freeze_time()
-    def test_requeue_for_later_retry(self, publish):
-        publish.side_effect = Exception
-        consumer = consumers.SNSConsumer()
-        task = SNSTask.objects.create(state=TaskStates.ENQUEUED)
-
-        consumer.process_task(task)
-        expected_visible_after = arrow.utcnow().shift(seconds=2).datetime
-        self.assertEquals(task.number_of_attempts, 1)
-        self.assertEquals(task.visible_after, expected_visible_after)
-        self.assertEquals(task.state, TaskStates.ENQUEUED)
-
-        with freezegun.freeze_time(arrow.utcnow().shift(seconds=5).datetime):
-            consumer.process_task(task)
-            expected_visible_after = arrow.utcnow().shift(seconds=4)
-
-        self.assertEquals(task.number_of_attempts, 2)
-        self.assertEquals(task.visible_after, expected_visible_after)
-        self.assertEquals(task.state, TaskStates.ENQUEUED)
-
-
-@mock.patch('mbq.metrics.Collector.timing')
-@mock.patch('mbq.metrics.Collector.increment')
-class SendTaskExecutionMetricsTest(TestCase):
-
-    def setUp(self):
-        freezer = freezegun.freeze_time()
-        freezer.start()
-        self.addCleanup(freezer.stop)
-
-        self.task = SNSTask.objects.create(
-            state=TaskStates.ENQUEUED,
-            number_of_attempts=2,
-            visible_after=arrow.utcnow().shift(seconds=0.012).datetime
-        )
-
-    def test_send_task_execution_metrics_error(self, increment, timing):
-        consumer = consumers.SNSConsumer()
-        execution_started_at = arrow.utcnow().shift(seconds=0.123)
-        execution_ended_at = arrow.utcnow().shift(seconds=0.579)
-        consumer.send_task_execution_metrics(self.task, execution_started_at, execution_ended_at)
-
-        expected_tags = {
-            'end_state': TaskStates.ENQUEUED,
-            'result': 'error',
-            'queue_type': 'sns',
-        }
-
-        increment.assert_called_once_with(
-            'task',
-            tags=expected_tags,
-        )
-
-        timing_call1 = mock.call(
-            'task.wait_time_ms',
-            111.0,
-            tags=expected_tags
-        )
-        timing_call2 = mock.call(
-            'task.execution_time_ms',
-            456.0,
-            tags=expected_tags
-        )
-        timing.assert_has_calls([timing_call1, timing_call2])
-
-    def test_send_task_execution_metrics_success(self, increment, timing):
-        self.task.state = TaskStates.SUCCEEDED
-        self.task.succeeded_at = arrow.utcnow().shift(seconds=0.805).datetime
-        self.task.save()
-
-        consumer = consumers.SNSConsumer()
-        execution_started_at = arrow.utcnow().shift(seconds=0.123)
-        execution_ended_at = arrow.utcnow().shift(seconds=0.579)
-        consumer.send_task_execution_metrics(self.task, execution_started_at, execution_ended_at)
-
-        expected_tags = {
-            'end_state': TaskStates.SUCCEEDED,
-            'result': 'success',
-            'queue_type': 'sns',
-        }
-
-        increment.assert_called_once_with(
-            'task',
-            tags=expected_tags,
-        )
-
-        timing_call1 = mock.call(
-            'task.wait_time_ms',
-            111.0,
-            tags=expected_tags
-        )
-        timing_call2 = mock.call(
-            'task.execution_time_ms',
-            456.0,
-            tags=expected_tags
-        )
-        timing_call3 = mock.call(
-            'task.turnaround_time_ms',
-            805.0,
-            tags=expected_tags
-        )
-        timing.assert_has_calls([timing_call1, timing_call2, timing_call3])
+        self.assertEquals(task.state, TaskStates.SUCCEEDED)
+        self.assertEquals(task.number_of_attempts, MAX_ATTEMPTS_TO_PROCESS_TASKS)
+        self.assertIsNotNone(task.succeeded_at)


### PR DESCRIPTION
All tests will fail right now, i just wanted to get some eyes on this so if something doesn't look right i'm not wasting my time on re-writing tests.

The main motivation was removing sleep statements out of consumer class. I think it makes sense for the Consumer to be responsible for processing tasks but flow control should probably live in the consumer mgmt command. 

Also I think now it's a little easier to add any other error metrics we want if we want them.