### PR TITLE
Ps/test with postgres too

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ env:
     - DJANGO=master
   matrix:
     - DATABASE_URL=mysql://root:@127.0.0.1:3306/atomiqdb
-    - DATABASE_URL=postgres://postgres:postgres@127.0.0.1:5432/atomiqpg
+    - DATABASE_URL=postgres://postgres:@127.0.0.1:5432/atomiqpg
 
 matrix:
   fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,9 +27,6 @@ matrix:
   include:
     - { python: '3.6', env: TOXENV=lint }
 
-  allow_failures:
-    - env: DJANGO=master
-
 before_install:
   - mysql -e 'CREATE DATABASE atomiqdb;'
   - psql -c 'CREATE DATABASE atomiqpg;' -U postgres

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,19 +8,16 @@ services:
 
 python:
   - '3.6'
-  - '3.7-dev'
-  - 'pypy3'
+  - '3.7'
 
 env:
   matrix:
     - DJANGO=1.11 DATABASE_URL=mysql://root:@127.0.0.1:3306/atomiqdb
     - DJANGO=2.0 DATABASE_URL=mysql://root:@127.0.0.1:3306/atomiqdb
     - DJANGO=2.1 DATABASE_URL=mysql://root:@127.0.0.1:3306/atomiqdb
-    - DJANGO=master DATABASE_URL=mysql://root:@127.0.0.1:3306/atomiqdb
     - DJANGO=1.11 DATABASE_URL=postgres://postgres:@127.0.0.1:5432/atomiqpg
     - DJANGO=2.0 DATABASE_URL=postgres://postgres:@127.0.0.1:5432/atomiqpg
     - DJANGO=2.1 DATABASE_URL=postgres://postgres:@127.0.0.1:5432/atomiqpg
-    - DJANGO=master DATABASE_URL=postgres://postgres:@127.0.0.1:5432/atomiqpg
 
 matrix:
   fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ cache: pip
 
 services:
   - mysql
+  - postgresql
 
 python:
   - '3.6'
@@ -16,8 +17,9 @@ env:
     - DJANGO=2.0
     - DJANGO=2.1
     - DJANGO=master
-  global:
+  matrix:
     - DATABASE_URL=mysql://root:@127.0.0.1:3306/atomiqdb
+    - DATABASE_URL=postgres://postgres:postgres@127.0.0.1:5432/atomiq-pg
 
 matrix:
   fast_finish: true
@@ -28,7 +30,8 @@ matrix:
     - env: DJANGO=master
 
 before_install:
-  - mysql -e 'CREATE DATABASE atmoiqdb;'
+  - mysql -e 'CREATE DATABASE atomiqdb;'
+  - psql -c 'CREATE DATABASE atomiq-pg;' -U postgres
 
 install:
   - travis_retry pip install --upgrade pip tox tox-venv tox-travis

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,13 +13,14 @@ python:
 
 env:
   matrix:
-    - DJANGO=1.11
-    - DJANGO=2.0
-    - DJANGO=2.1
-    - DJANGO=master
-  matrix:
-    - DATABASE_URL=mysql://root:@127.0.0.1:3306/atomiqdb
-    - DATABASE_URL=postgres://postgres:@127.0.0.1:5432/atomiqpg
+    - DJANGO=1.11 DATABASE_URL=mysql://root:@127.0.0.1:3306/atomiqdb
+    - DJANGO=2.0 DATABASE_URL=mysql://root:@127.0.0.1:3306/atomiqdb
+    - DJANGO=2.1 DATABASE_URL=mysql://root:@127.0.0.1:3306/atomiqdb
+    - DJANGO=master DATABASE_URL=mysql://root:@127.0.0.1:3306/atomiqdb
+    - DJANGO=1.11 DATABASE_URL=postgres://postgres:@127.0.0.1:5432/atomiqpg
+    - DJANGO=2.0 DATABASE_URL=postgres://postgres:@127.0.0.1:5432/atomiqpg
+    - DJANGO=2.1 DATABASE_URL=postgres://postgres:@127.0.0.1:5432/atomiqpg
+    - DJANGO=master DATABASE_URL=postgres://postgres:@127.0.0.1:5432/atomiqpg
 
 matrix:
   fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,12 +12,12 @@ python:
 
 env:
   matrix:
-    - DJANGO=1.11 DATABASE_URL=mysql://root:@127.0.0.1:3306/atomiqdb
-    - DJANGO=2.0 DATABASE_URL=mysql://root:@127.0.0.1:3306/atomiqdb
-    - DJANGO=2.1 DATABASE_URL=mysql://root:@127.0.0.1:3306/atomiqdb
-    - DJANGO=1.11 DATABASE_URL=postgres://postgres:@127.0.0.1:5432/atomiqpg
-    - DJANGO=2.0 DATABASE_URL=postgres://postgres:@127.0.0.1:5432/atomiqpg
-    - DJANGO=2.1 DATABASE_URL=postgres://postgres:@127.0.0.1:5432/atomiqpg
+    - DJANGO=1.11 DB=mysql DATABASE_URL=mysql://root:@127.0.0.1:3306/atomiqdb
+    - DJANGO=1.11 DB=postgres DATABASE_URL=postgres://postgres:@127.0.0.1:5432/atomiqpg
+    - DJANGO=2.0 DB=mysql DATABASE_URL=mysql://root:@127.0.0.1:3306/atomiqdb
+    - DJANGO=2.0 DB=postgres DATABASE_URL=postgres://postgres:@127.0.0.1:5432/atomiqpg
+    - DJANGO=2.1 DB=mysql DATABASE_URL=mysql://root:@127.0.0.1:3306/atomiqdb
+    - DJANGO=2.1 DB=postgres DATABASE_URL=postgres://postgres:@127.0.0.1:5432/atomiqpg
 
 matrix:
   fast_finish: true
@@ -51,5 +51,5 @@ deploy:
     # on exactly one build, not all py36 builds, and looking for django 1.11 is a cheap
     # way to accomplish that.
     condition: $DJANGO = '1.11'
-    condition: $DATABASE_URL = 'postgres://postgres:@127.0.0.1:5432/atomiqpg'
+    condition: $DB = 'postgres'
     distributions: sdist bdist_wheel

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ env:
     - DJANGO=master
   matrix:
     - DATABASE_URL=mysql://root:@127.0.0.1:3306/atomiqdb
-    - DATABASE_URL=postgres://postgres:postgres@127.0.0.1:5432/atomiq-pg
+    - DATABASE_URL=postgres://postgres:postgres@127.0.0.1:5432/atomiqpg
 
 matrix:
   fast_finish: true
@@ -31,7 +31,7 @@ matrix:
 
 before_install:
   - mysql -e 'CREATE DATABASE atomiqdb;'
-  - psql -c 'CREATE DATABASE atomiq-pg;' -U postgres
+  - psql -c 'CREATE DATABASE atomiqpg;' -U postgres
 
 install:
   - travis_retry pip install --upgrade pip tox tox-venv tox-travis

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,4 +57,5 @@ deploy:
     # on exactly one build, not all py36 builds, and looking for django 1.11 is a cheap
     # way to accomplish that.
     condition: $DJANGO = '1.11'
+    condition: $DATABASE_URL = 'postgres://postgres:@127.0.0.1:5432/atomiqpg'
     distributions: sdist bdist_wheel

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ services:
 
 python:
   - '3.6'
-  - '3.7'
+  - '3.7-dev'
 
 env:
   matrix:

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,4 +4,3 @@ WORKDIR /tox
 WORKDIR /app
 COPY . .
 RUN pip install --upgrade pip tox tox-venv tox-travis
-CMD tox -e "$(tox --listenvs-all | grep "$PYTHON_VERSION-" | tr '\n' ',')"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,21 +32,6 @@ services:
       DATABASE_URL: 'mysql://root:@mysql:3306/atomiqdb'
     command: tox -e py36-django{111,20,21,master}-mysql
 
-  pypy3-mysql:
-    build:
-      context: .
-      args:
-        IMAGE: 'pypy:3-6-jessie'
-    volumes:
-      - .:/app
-    links:
-      - mysql
-    environment:
-      TOX_WORK_DIR: /tox
-      PYTHON_VERSION: pypy3
-      DATABASE_URL: 'mysql://root:@mysql:3306/atomiqdb'
-    command: tox -e py36-django{111,20,21,master}-mysql
-
   mysql:
     image: mysql:5.6
     environment:
@@ -80,21 +65,6 @@ services:
     environment:
       TOX_WORK_DIR: /tox
       PYTHON_VERSION: py37
-      DATABASE_URL: 'postgres://postgres:postgres@postgres:5432/atomiq-pg'
-    command: tox -e py36-django{111,20,21,master}-pg
-
-  pypy3-pg:
-    build:
-      context: .
-      args:
-        IMAGE: 'pypy:3-6-jessie'
-    volumes:
-      - .:/app
-    links:
-       - postgres
-    environment:
-      TOX_WORK_DIR: /tox
-      PYTHON_VERSION: pypy3
       DATABASE_URL: 'postgres://postgres:postgres@postgres:5432/atomiq-pg'
     command: tox -e py36-django{111,20,21,master}-pg
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       TOX_WORK_DIR: /tox
       PYTHON_VERSION: py36
       DATABASE_URL: 'mysql://root:@mysql:3306/atomiqdb'
-    command: tox -e py36-django{111,20,21,master}-mysql
+    command: tox -e py36-django{111,20,21}-mysql
 
   py37-mysql:
     build:
@@ -30,7 +30,7 @@ services:
       TOX_WORK_DIR: /tox
       PYTHON_VERSION: py37
       DATABASE_URL: 'mysql://root:@mysql:3306/atomiqdb'
-    command: tox -e py36-django{111,20,21,master}-mysql
+    command: tox -e py36-django{111,20,21}-mysql
 
   mysql:
     image: mysql:5.6
@@ -51,7 +51,7 @@ services:
       TOX_WORK_DIR: /tox
       PYTHON_VERSION: py36
       DATABASE_URL: 'postgres://postgres:postgres@postgres:5432/atomiq-pg'
-    command: tox -e py36-django{111,20,21,master}-pg
+    command: tox -e py36-django{111,20,21}-pg
 
   py37-pg:
     build:
@@ -66,7 +66,7 @@ services:
       TOX_WORK_DIR: /tox
       PYTHON_VERSION: py37
       DATABASE_URL: 'postgres://postgres:postgres@postgres:5432/atomiq-pg'
-    command: tox -e py36-django{111,20,21,master}-pg
+    command: tox -e py36-django{111,20,21}-pg
 
   postgres:
     image: postgres:9.6.8

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@
 version: '3'
 
 services:
-  py36:
+  py36-mysql:
     build:
       context: .
       args:
@@ -14,8 +14,10 @@ services:
     environment:
       TOX_WORK_DIR: /tox
       PYTHON_VERSION: py36
+      DATABASE_URL: 'mysql://root:@mysql:3306/atomiqdb'
+    command: tox -e py36-django{111,20,21,master}-mysql
 
-  py37:
+  py37-mysql:
     build:
       context: .
       args:
@@ -27,8 +29,10 @@ services:
     environment:
       TOX_WORK_DIR: /tox
       PYTHON_VERSION: py37
+      DATABASE_URL: 'mysql://root:@mysql:3306/atomiqdb'
+    command: tox -e py36-django{111,20,21,master}-mysql
 
-  pypy3:
+  pypy3-mysql:
     build:
       context: .
       args:
@@ -40,11 +44,65 @@ services:
     environment:
       TOX_WORK_DIR: /tox
       PYTHON_VERSION: pypy3
+      DATABASE_URL: 'mysql://root:@mysql:3306/atomiqdb'
+    command: tox -e py36-django{111,20,21,master}-mysql
 
   mysql:
     image: mysql:5.6
     environment:
       - MYSQL_DATABASE=atomiqdb
       - MYSQL_ALLOW_EMPTY_PASSWORD=yes
+
+  py36-pg:
+    build:
+      context: .
+      args:
+        IMAGE: 'python:3.6-stretch'
+    volumes:
+      - .:/app
+    links:
+       - postgres
+    environment:
+      TOX_WORK_DIR: /tox
+      PYTHON_VERSION: py36
+      DATABASE_URL: 'postgres://postgres:postgres@postgres:5432/atomiq-pg'
+    command: tox -e py36-django{111,20,21,master}-pg
+
+  py37-pg:
+    build:
+      context: .
+      args:
+        IMAGE: 'python:3.7-stretch'
+    volumes:
+      - .:/app
+    links:
+       - postgres
+    environment:
+      TOX_WORK_DIR: /tox
+      PYTHON_VERSION: py37
+      DATABASE_URL: 'postgres://postgres:postgres@postgres:5432/atomiq-pg'
+    command: tox -e py36-django{111,20,21,master}-pg
+
+  pypy3-pg:
+    build:
+      context: .
+      args:
+        IMAGE: 'pypy:3-6-jessie'
+    volumes:
+      - .:/app
+    links:
+       - postgres
+    environment:
+      TOX_WORK_DIR: /tox
+      PYTHON_VERSION: pypy3
+      DATABASE_URL: 'postgres://postgres:postgres@postgres:5432/atomiq-pg'
+    command: tox -e py36-django{111,20,21,master}-pg
+
+  postgres:
+    image: postgres:9.6.8
+    environment:
+      POSTGRES_DB: atomiq-pg
+
+
 
 

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -14,7 +14,6 @@ ATOMIQ = {
 }
 
 database_url = os.environ.get('DATABASE_URL', 'mysql://root:@mysql:3306/atomiqdb')
-print('DATABASE URL: ', database_url)
 DATABASES = {
     'default': dj_database_url.parse(database_url),
 }

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -14,6 +14,7 @@ ATOMIQ = {
 }
 
 database_url = os.environ.get('DATABASE_URL', 'mysql://root:@mysql:3306/atomiqdb')
+print('DATABASE URL: ', database_url)
 DATABASES = {
     'default': dj_database_url.parse(database_url),
 }

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -33,7 +33,6 @@ class TaskTest(TestCase):
         )
 
         tasks = SNSTask.objects.available_for_processing()
-        # import pdb; pdb.set_trace()
         self.assertEquals(list(tasks), [
             task_ready_past,
             task_ready_now,

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -18,7 +18,6 @@ class TaskTest(TestCase):
         # deleted task
         SNSTask.objects.create(state=TaskStates.DELETED)
 
-        task_ready = SNSTask.objects.create(state=TaskStates.ENQUEUED)
         task_ready_past = SNSTask.objects.create(
             state=TaskStates.ENQUEUED,
             visible_after=arrow.utcnow().shift(seconds=-1).datetime,
@@ -34,8 +33,8 @@ class TaskTest(TestCase):
         )
 
         tasks = SNSTask.objects.available_for_processing()
+        # import pdb; pdb.set_trace()
         self.assertEquals(list(tasks), [
             task_ready_past,
-            task_ready,
             task_ready_now,
         ])

--- a/tox.ini
+++ b/tox.ini
@@ -28,7 +28,7 @@ deps =
     django20: Django>=2.0,<2.1
     django21: Django>=2.1,<2.2
     django{111,20}-mysql: mysqlclient==1.3.6
-    django{21}-mysql: mysqlclient==1.3.7
+    django21-mysql: mysqlclient==1.3.7
     pg: psycopg2==2.7.5
 
 [testenv:lint]

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,7 @@ DJANGO =
     master: djangomaster
 DATABASE_URL =
     "mysql://root:@127.0.0.1:3306/atomiqdb": mysql
-    "postgres://postgres:postgres@127.0.0.1:5432/atomiq-pg": pg
+    "postgres://postgres:@127.0.0.1:5432/atomiqpg": pg
 
 [testenv]
 commands = python -m runtests

--- a/tox.ini
+++ b/tox.ini
@@ -11,10 +11,9 @@ DJANGO =
     2.0: django20
     2.1: django21
     master: djangomaster
-[travis:env]
 DATABASE_URL =
-    "mysql://root:@127.0.0.1:3306/atomiqdb": mysql
-    "postgres://postgres:@127.0.0.1:5432/atomiqpg": pg
+    mysql: mysql
+    postgres: pg
 
 [testenv]
 commands = python -m runtests

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,7 @@
 [tox]
 toxworkdir = {env:TOX_WORK_DIR:.tox}
 envlist =
-       {py35,py36,py37,pypy3}-django111-{mysql,pg},
-       {py36,py37,pypy3}-django{20,21,master}-{mysql,pg},
+       {py36,py37}-django{111,20,21}-{mysql,pg},
        lint
 skip_missing_interpreters = True
 

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,6 @@ DJANGO =
     1.11: django111
     2.0: django20
     2.1: django21
-    master: djangomaster
 DB =
     mysql: mysql
     postgres: pg
@@ -29,7 +28,7 @@ deps =
     django20: Django>=2.0,<2.1
     django21: Django>=2.1,<2.2
     django{111,20}-mysql: mysqlclient==1.3.6
-    django{21,master}-mysql: mysqlclient==1.3.7
+    django{21}-mysql: mysqlclient==1.3.7
     pg: psycopg2==2.7.5
 
 [testenv:lint]

--- a/tox.ini
+++ b/tox.ini
@@ -31,7 +31,6 @@ deps =
     django{111,20}-mysql: mysqlclient==1.3.6
     django{21,master}-mysql: mysqlclient==1.3.7
     pg: psycopg2==2.7.5
-    djangomaster: https://github.com/django/django/archive/master.tar.gz
 
 [testenv:lint]
 commands = flake8

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ DJANGO =
     2.0: django20
     2.1: django21
     master: djangomaster
-DATABASE_URL =
+DB =
     mysql: mysql
     postgres: pg
 

--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,7 @@ DJANGO =
     2.0: django20
     2.1: django21
     master: djangomaster
+[travis:env]
 DATABASE_URL =
     "mysql://root:@127.0.0.1:3306/atomiqdb": mysql
     "postgres://postgres:@127.0.0.1:5432/atomiqpg": pg

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 toxworkdir = {env:TOX_WORK_DIR:.tox}
 envlist =
-       {py35,py36,py37,pypy3}-django111,
-       {py36,py37,pypy3}-django{20,21,master},
+       {py35,py36,py37,pypy3}-django111-{mysql,pg},
+       {py36,py37,pypy3}-django{20,21,master}-{mysql,pg},
        lint
 skip_missing_interpreters = True
 
@@ -26,8 +26,9 @@ deps =
     django111: Django>=1.11,<2.0
     django20: Django>=2.0,<2.1
     django21: Django>=2.1,<2.2
-    django{111,20}: mysqlclient==1.3.6
-    django{21,master}: mysqlclient==1.3.7
+    django{111,20}-mysql: mysqlclient==1.3.6
+    django{21,master}-mysql: mysqlclient==1.3.7
+    pg: psycopg2==2.7.5
     djangomaster: https://github.com/django/django/archive/master.tar.gz
 
 [testenv:lint]

--- a/tox.ini
+++ b/tox.ini
@@ -12,6 +12,9 @@ DJANGO =
     2.0: django20
     2.1: django21
     master: djangomaster
+DATABASE_URL =
+    "mysql://root:@127.0.0.1:3306/atomiqdb": mysql
+    "postgres://postgres:postgres@127.0.0.1:5432/atomiq-pg": pg
 
 [testenv]
 commands = python -m runtests


### PR DESCRIPTION
I removed tests with `py35`, `djangomaster`, and `pypy3` to shrink the build matrix. Yes, these could be set up to have "allowed failures", but I still chose to remove them because Travis is throttling our builds which makes development on these libraries a pain. Includin extra builds is exacerbating that problem for very little benefit.