### PR TITLE
Test Util to reset celery publishes for a given task

### DIFF
--- a/mbq/atomiq/test_utils.py
+++ b/mbq/atomiq/test_utils.py
@@ -26,7 +26,7 @@ def get_sqs_publish_payloads(queue_url):
 
 
 def reset_celery_publishes(task):
-    tasks = models.CeleryTask.objects.filter(
+    models.CeleryTask.objects.filter(
         state=constants.TaskStates.ENQUEUED,
         task_name=task.name,
     ).delete()

--- a/mbq/atomiq/test_utils.py
+++ b/mbq/atomiq/test_utils.py
@@ -23,3 +23,10 @@ def get_sqs_publish_payloads(queue_url):
         queue_url=queue_url,
     )
     return [task.payload for task in tasks]
+
+
+def reset_celery_publishes(task):
+    tasks = models.CeleryTask.objects.filter(
+        state=constants.TaskStates.ENQUEUED,
+        task_name=task.name,
+    ).delete()

--- a/tests/test_test_utils.py
+++ b/tests/test_test_utils.py
@@ -48,6 +48,11 @@ class CeleryTestUtilsTest(TestCase):
         celery_publish_args = test_utils.get_celery_publish_args(nonexistant_task)
         self.assertEquals(celery_publish_args, [])
 
+    def test_reset_celery_tasks(self):
+        test_utils.reset_celery_publishes(self.task)
+        celery_publish_args = test_utils.get_celery_publish_args(self.task)
+        self.assertEquals(celery_publish_args, [])
+
 
 class SNSTestUtilsTest(TestCase):
 


### PR DESCRIPTION
I've run into this a few times -- in a test I want to assert that a task is _not_ called, but in order to get the data setup to run the test I perform an operation that causes a task to get published. One example can be seen in this PR: https://github.com/managedbyq/os-core/pull/8908